### PR TITLE
Cambio en el orden de las categorias de socio y saqué el active

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -160,21 +160,6 @@
 					<div class="col-md-4 wow fadeIn" data-wow-delay="0.6s">
 						<div class="pricing text-uppercase">
 							<div class="pricing-title">
-								<h4>Socio Adherente</h4>
-								<p>$75</p>
-								<small class="text-lowercase">mensual</small>
-							</div>
-							<ul>
-								<li>Participación parcial (Voz)</li>
-								<li>Aporte económico diferenciado</li>
-								<li>Entusiastas y Profesionales</li>
-							</ul>
-							<a href="https://goo.gl/forms/ungPJgQLpzVZAZ9B2" target="_blank" class="btn btn-primary text-uppercase">Asociate</a>
-						</div>
-					</div>
-					<div class="col-md-4 wow fadeIn" data-wow-delay="0.6s">
-						<div class="pricing active text-uppercase">
-							<div class="pricing-title">
 								<h4>Socio Activo</h4>
 								<p>$200</p>
 								<small class="text-lowercase">mensual</small>
@@ -183,6 +168,21 @@
 								<li>Participación Completa (Voz y Voto)</li>
 								<li>Aporte económico</li>
 								<li>Elegible para cargos directivos</li>
+							</ul>
+							<a href="https://goo.gl/forms/ungPJgQLpzVZAZ9B2" target="_blank" class="btn btn-primary text-uppercase">Asociate</a>
+						</div>
+					</div>
+					<div class="col-md-4 wow fadeIn" data-wow-delay="0.6s">
+						<div class="pricing text-uppercase">
+							<div class="pricing-title">
+								<h4>Socio Adherente</h4>
+								<p>$75</p>
+								<small class="text-lowercase">mensual</small>
+							</div>
+							<ul>
+								<li>Participación parcial (Voz)</li>
+								<li>Aporte económico diferenciado</li>
+								<li>Entusiastas y Profesionales</li>
 							</ul>
 							<a href="https://goo.gl/forms/ungPJgQLpzVZAZ9B2" target="_blank" class="btn btn-primary text-uppercase">Asociate</a>
 						</div>


### PR DESCRIPTION
Después de hablar con Facundo y Nico cambié el orden de las categorías de socio (dejando al adherente primero) y quité la clase "active" que hacía que socio adherente se viera más "alta" que las otras categorías