### PR TITLE
Agrego en css las clases platinum, gold y silver

### DIFF
--- a/docs/css/templatemo-style.css
+++ b/docs/css/templatemo-style.css
@@ -408,6 +408,24 @@ img
 
 /* end download */
 
+/* start benefactoras */
+.platinum
+    {
+        width: 100%;
+        height: 100%;
+    }
+.gold
+    {
+        width: 70%;
+        height: 70%;
+    }
+.silver
+    {
+        width: 40%;
+        height: 40%;
+    }
+/* end benefactoras */
+
 /* start contact */
 #contacto
     {


### PR DESCRIPTION
Se deberia encerrar las imagenes con un div  que sean de la clase
que corresponda, ejemplo:

```
<div class="platinum">
    <a href="https://www.onapsis.com/"><img src="images/socixs/onapsis.png" class="img-responsive" alt="Onapsis"></a>
</div>
<div class="gold">
    <a href="https://www.onapsis.com/"><img src="images/socixs/onapsis.png" class="img-responsive" alt="Onapsis"></a>
</div>
<div class="silver">
    <a href="https://www.onapsis.com/"><img src="images/socixs/onapsis.png" class="img-responsive" alt="Onapsis"></a>
</div>
```

De esta manera la imagen va a ser de diferentes tamaños.


Se debería cambiar los porcentajes a gusto :-)