### PR TITLE
Agregar párrafo sobre uso de lenguaje inclusivo dentro de PyAr

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -210,8 +210,8 @@
 						<p>
 							Desde la asociación reconocemos y valoramos las distintas variantes de lenguaje inclusivo, y las mismas son bienvenidas en la comunidad. 
 							No imponemos oficialmente ninguna de ellas en nuestros espacios, pero no toleramos que se cuestione o intente impedir su uso.
-							Si te molesta que otra persona esté utilizando lenguaje inclusivo, PyAr no es el lugar para intentar impedírselo, debatirlo, expresar tu oposición o molestia frente ello.
-							Este tipo de acciones orientadas a cuestionar su uso por parte de otras personas, son consideradas violaciones al código de conducta.
+							Si te molesta que otra persona esté utilizando lenguaje inclusivo, PyAr no es el lugar para intentar impedírselo, debatirlo, cuestionar su validez o correctitud, expresar tu oposición o molestia frente ello.
+							Este tipo de respuestas negativas frente a su uso, son consideradas violaciones al código de conducta.
 						</p>
 						<h3>INFORMACIÓN DE CONTACTO</h3>
 						<p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -208,10 +208,10 @@
 							Tenga cuidado con las palabras que elija. Recuerde que los chistes de exclusión sexistas, racistas, y otros pueden ser ofensivos para quienes le rodean.
 						</p>
 						<p>
-                            Desde la asociación reconocemos y valoramos las distintas variantes de lenguaje inclusivo, y las mismas son bienvenidas en la comunidad. 
-                            No imponemos oficialmente ninguna de ellas en nuestros espacios, pero no toleramos que se cuestione o intente impedir su uso.
-                            Si te molesta que otra persona esté utilizando lenguaje inclusivo, PyAr no es el lugar para intentar impedírselo, debatirlo, expresar tu oposición o molestia frente ello.
-                            Este tipo de acciones orientadas a cuestionar su uso por parte de otras personas, son consideradas violaciones al código de conducta.
+							Desde la asociación reconocemos y valoramos las distintas variantes de lenguaje inclusivo, y las mismas son bienvenidas en la comunidad. 
+							No imponemos oficialmente ninguna de ellas en nuestros espacios, pero no toleramos que se cuestione o intente impedir su uso.
+							Si te molesta que otra persona esté utilizando lenguaje inclusivo, PyAr no es el lugar para intentar impedírselo, debatirlo, expresar tu oposición o molestia frente ello.
+							Este tipo de acciones orientadas a cuestionar su uso por parte de otras personas, son consideradas violaciones al código de conducta.
 						</p>
 						<h3>INFORMACIÓN DE CONTACTO</h3>
 						<p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -207,6 +207,12 @@
 							Se espera un comportamiento profesional, no insulte o desprecie a otros integrantes de la comunidad.
 							Tenga cuidado con las palabras que elija. Recuerde que los chistes de exclusión sexistas, racistas, y otros pueden ser ofensivos para quienes le rodean.
 						</p>
+						<p>
+                            Desde la asociación reconocemos y valoramos las distintas variantes de lenguaje inclusivo, y las mismas son bienvenidas en la comunidad. 
+                            No imponemos oficialmente ninguna de ellas en nuestros espacios, pero no toleramos que se cuestione o intente impedir su uso.
+                            Si te molesta que otra persona esté utilizando lenguaje inclusivo, PyAr no es el lugar para intentar impedírselo, debatirlo, expresar tu oposición o molestia frente ello.
+                            Este tipo de acciones orientadas a cuestionar su uso por parte de otras personas, son consideradas violaciones al código de conducta.
+						</p>
 						<h3>INFORMACIÓN DE CONTACTO</h3>
 						<p>
 							Si eres objeto de acoso, notas que alguien más está siendo acosado, o tienes cualquier otro reclamo o inquietud, por favor contáctate con un miembro de la Comisión Directiva de la asociación.


### PR DESCRIPTION
Aclaración de que a pesar de que no imponemos uso de lenguaje inclusivo, tampoco toleramos que se esté intentando impedir o cuestionar a quienes lo usen. Y que incluso valoramos y bienvenimos su uso.